### PR TITLE
[재영] 네트워크

### DIFF
--- a/bfs-dfs/network/JengYoung/index.js
+++ b/bfs-dfs/network/JengYoung/index.js
@@ -1,0 +1,22 @@
+const findParent = (x, parent) => {
+  return parent[x] === x ? x : findParent(parent[x], parent);
+};
+
+const updateParent = (a, b, parent) => {
+  const parentA = findParent(a, parent);
+  const parentB = findParent(b, parent);
+  if (parentA < parentB) parent[parentB] = parent[parentA];
+  if (parentB < parentA) parent[parentA] = parent[parentB];
+};
+
+const solution = (n, computers) => {
+  const parent = Array.from({ length: n }, (_, idx) => idx);
+  computers.forEach((arr, rowIdx) => {
+    arr.forEach((value, colIdx) => {
+      if (rowIdx === colIdx) return;
+      if (value) updateParent(rowIdx, colIdx, parent);
+    });
+  });
+
+  return parent.filter((val, idx) => val === idx).length;
+};


### PR DESCRIPTION
### 풀이 과정 요약
`BFS`로 푸는 방법도 있겠으나, `union-find`의 방식으로 풀이를 하였습니다.

### 상세 내용
일단 `BFS`로 푼다면 다음과 같은 방식으로 하였을 듯 합니다. 
1. 방문 여부를 판단하는 `visited`를 생성한다.
2. `for`문을 통해서 연결이 된 노드를 탐색한다.
3. 만약 연결이 되어 있지만 `visited`에 없다면 `queue`에 넣는다.
4. queue가 다 비어질 때까지 진행한다. 
5. `for`문으로 계속 탐색하다가, 아직 `visited`가 없는 노드라면 cnt(네트워크 수)를 1 올린다.
6. 계속 같은 방식으로 진행한다.

다만 '연결'이라는 부분에 초점을 맞췄을 때, 유니온 파인드가 더욱 적절할 것 같다고 생각했습니다.
과정은 다음과 같습니다.
1. 기존 노드에 대한 부모를 판단하는 `parent`를 만든다.
2. `for`문을 돌릴 때 서로의 부모가 같은지를 판별한다.
3. 만약 다르다면 부모를 통일시켜준다.
4. 결과적으로 부모 노드의 개수만 판별하면 된다. 따라서 `filter`을 통해 인덱스가 값과 같은지 확인한다.
